### PR TITLE
Add net10.0-windows10.0.26100 targets to uno-port

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>12</LangVersion>
     <!-- https://github.com/dotnet/msbuild/issues/2661 -->
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>

--- a/samples/TreeDataGridDemo/TreeDataGridDemo.csproj
+++ b/samples/TreeDataGridDemo/TreeDataGridDemo.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Bogus" Version="34.0.2" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
     <ProjectReference Include="..\..\src\Avalonia.Controls.TreeDataGrid\Avalonia.Controls.TreeDataGrid.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/TreeDataGridUnoSample/App.xaml
+++ b/samples/TreeDataGridUnoSample/App.xaml
@@ -1,42 +1,13 @@
 <Application
     x:Class="TreeDataGridUnoSample.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:m="using:TreeDataGridDemo.Models">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
                 <ResourceDictionary Source="ms-appx:///TreeDataGrid.Uno/Themes/Generic.xaml" />
             </ResourceDictionary.MergedDictionaries>
-
-            <DataTemplate x:Key="RegionCell" x:DataType="m:Country">
-                <TextBlock Text="{x:Bind Region}" />
-            </DataTemplate>
-
-            <DataTemplate x:Key="RegionEditCell" x:DataType="m:Country">
-                <ComboBox ItemsSource="{x:Bind m:Countries.Regions}"
-                          MinWidth="180"
-                          SelectedItem="{x:Bind Region, Mode=TwoWay}" />
-            </DataTemplate>
-
-            <DataTemplate x:Key="FileNameCell" x:DataType="m:FileTreeNodeModel">
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <Image Width="16" Height="16" Source="{x:Bind IconSource, Mode=OneWay}" />
-                    <TextBlock VerticalAlignment="Center" Text="{x:Bind Name}" />
-                </StackPanel>
-            </DataTemplate>
-
-            <DataTemplate x:Key="FileNameEditCell" x:DataType="m:FileTreeNodeModel">
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <Image Width="16" Height="16" Source="{x:Bind IconSource, Mode=OneWay}" />
-                    <TextBox MinWidth="220" Text="{x:Bind Name, Mode=TwoWay}" />
-                </StackPanel>
-            </DataTemplate>
-
-            <DataTemplate x:Key="WikipediaImageCell" x:DataType="m:OnThisDayArticle">
-                <Image MaxHeight="72" Stretch="Uniform" Source="{x:Bind Image, Mode=OneWay}" />
-            </DataTemplate>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/samples/TreeDataGridUnoSample/Directory.Build.props
+++ b/samples/TreeDataGridUnoSample/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <!-- Uno.Sdk requires workload resolution and defines its own TargetFrameworks -->
+    <TargetFramework />
+    <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>
+  </PropertyGroup>
+</Project>

--- a/samples/TreeDataGridUnoSample/MainPage.xaml
+++ b/samples/TreeDataGridUnoSample/MainPage.xaml
@@ -5,6 +5,37 @@
     xmlns:controls="using:Uno.Controls"
     xmlns:m="using:TreeDataGridDemo.Models"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Page.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="RegionCell" x:DataType="m:Country">
+                <TextBlock Text="{x:Bind Region}" />
+            </DataTemplate>
+
+            <DataTemplate x:Key="RegionEditCell" x:DataType="m:Country">
+                <ComboBox ItemsSource="{x:Bind m:Countries.Regions}"
+                          MinWidth="180"
+                          SelectedItem="{x:Bind Region, Mode=TwoWay}" />
+            </DataTemplate>
+
+            <DataTemplate x:Key="FileNameCell" x:DataType="m:FileTreeNodeModel">
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <Image Width="16" Height="16" Source="{x:Bind IconSource, Mode=OneWay}" />
+                    <TextBlock VerticalAlignment="Center" Text="{x:Bind Name}" />
+                </StackPanel>
+            </DataTemplate>
+
+            <DataTemplate x:Key="FileNameEditCell" x:DataType="m:FileTreeNodeModel">
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <Image Width="16" Height="16" Source="{x:Bind IconSource, Mode=OneWay}" />
+                    <TextBox MinWidth="220" Text="{x:Bind Name, Mode=TwoWay}" />
+                </StackPanel>
+            </DataTemplate>
+
+            <DataTemplate x:Key="WikipediaImageCell" x:DataType="m:OnThisDayArticle">
+                <Image MaxHeight="72" Stretch="Uniform" Source="{x:Bind Image, Mode=OneWay}" />
+            </DataTemplate>
+        </ResourceDictionary>
+    </Page.Resources>
     <Grid Padding="12">
         <TabView x:Name="tabs"
                  HorizontalAlignment="Stretch"

--- a/samples/TreeDataGridUnoSample/Properties/launchSettings.json
+++ b/samples/TreeDataGridUnoSample/Properties/launchSettings.json
@@ -33,9 +33,17 @@
     },
     "TreeDataGridUnoSample (Desktop WSL2)": {
       "commandName": "WSL2",
-      "commandLineArgs": "{ProjectDir}/bin/Debug/net9.0-desktop/TreeDataGridUnoSample.dll",
+      "commandLineArgs": "{ProjectDir}/bin/Debug/net10.0-desktop/TreeDataGridUnoSample.dll",
       "distributionName": "",
       "compatibleTargetFramework": "desktop"
+    },
+    "TreeDataGridUnoSample (WinAppSDK Packaged)": {
+      "commandName": "MsixPackage",
+      "compatibleTargetFramework": "windows"
+    },
+    "TreeDataGridUnoSample (WinAppSDK Unpackaged)": {
+      "commandName": "Project",
+      "compatibleTargetFramework": "windows"
     }
   }
 }

--- a/samples/TreeDataGridUnoSample/TreeDataGridUnoSample.csproj
+++ b/samples/TreeDataGridUnoSample/TreeDataGridUnoSample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Uno.Sdk/6.5.31">
-      <PropertyGroup>
+  <PropertyGroup>
         <TargetFramework></TargetFramework>
-        <TreeDataGridUnoSampleTargetFrameworks Condition="'$(TreeDataGridUnoSampleTargetFrameworks)' == ''">net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0-desktop</TreeDataGridUnoSampleTargetFrameworks>
-        <TargetFrameworks>$(TreeDataGridUnoSampleTargetFrameworks)</TargetFrameworks>
+        <TreeDataGridUnoSampleTargetFrameworks Condition="'$(TreeDataGridUnoSampleTargetFrameworks)' == ''">net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop;net10.0-windows10.0.26100</TreeDataGridUnoSampleTargetFrameworks>
+        <TargetFrameworks>$(TreeDataGridUnoSampleTargetFrameworks)</TargetFrameworks>       
         <OutputType>Exe</OutputType>
         <UnoSingleProject>true</UnoSingleProject>
         <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\TreeDataGrid.Uno\TreeDataGrid.Uno.csproj" />
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGridItemsSourceView.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGridItemsSourceView.cs
@@ -105,7 +105,11 @@ namespace Avalonia.Controls
                 {
                     if (_inner is INotifyCollectionChanged incc)
                     {
-                        CollectionChangedEventManager.Instance.AddListener(incc, this);
+#if TREE_DATAGRID_UNO
+                        Uno.Controls.Utils.CollectionChangedEventManager.Instance.AddListener(incc, this);
+#else
+                CollectionChangedEventManager.Instance.AddListener(incc, this);
+#endif
                     }
                 }
 
@@ -123,7 +127,11 @@ namespace Avalonia.Controls
                 {
                     if (_inner is INotifyCollectionChanged incc)
                     {
-                        CollectionChangedEventManager.Instance.RemoveListener(incc, this);
+#if TREE_DATAGRID_UNO
+                        Uno.Controls.Utils.CollectionChangedEventManager.Instance.RemoveListener(incc, this);
+#else
+                CollectionChangedEventManager.Instance.RemoveListener(incc, this);
+#endif
                     }
                 }
             }
@@ -134,7 +142,11 @@ namespace Avalonia.Controls
         {
             if (_inner is INotifyCollectionChanged incc)
             {
+#if TREE_DATAGRID_UNO
+                Uno.Controls.Utils.CollectionChangedEventManager.Instance.RemoveListener(incc, this);
+#else
                 CollectionChangedEventManager.Instance.RemoveListener(incc, this);
+#endif
             }
 
             _inner = null;
@@ -209,7 +221,11 @@ namespace Avalonia.Controls
         {
             if (Inner is INotifyCollectionChanged incc)
             {
-                CollectionChangedEventManager.Instance.AddListener(incc, listener);
+#if TREE_DATAGRID_UNO
+                Uno.Controls.Utils.CollectionChangedEventManager.Instance.AddListener(incc, this);
+#else
+                CollectionChangedEventManager.Instance.AddListener(incc, this);
+#endif
             }
         }
 
@@ -217,7 +233,11 @@ namespace Avalonia.Controls
         {
             if (Inner is INotifyCollectionChanged incc)
             {
-                CollectionChangedEventManager.Instance.RemoveListener(incc, listener);
+#if TREE_DATAGRID_UNO
+                Uno.Controls.Utils.CollectionChangedEventManager.Instance.RemoveListener(incc, this);
+#else
+                CollectionChangedEventManager.Instance.RemoveListener(incc, this);
+#endif
             }
         }
 

--- a/src/TreeDataGrid.Uno/Directory.Build.props
+++ b/src/TreeDataGrid.Uno/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <!-- Uno.Sdk requires workload resolution and defines its own TargetFrameworks -->
+    <TargetFramework />
+    <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>
+  </PropertyGroup>
+</Project>

--- a/src/TreeDataGrid.Uno/TreeDataGrid.Uno.csproj
+++ b/src/TreeDataGrid.Uno/TreeDataGrid.Uno.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Uno.Sdk/6.5.31">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net10.0;net10.0-desktop;net10.0-windows10.0.26100</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
     <RootNamespace>Uno.Controls</RootNamespace>
@@ -10,12 +10,9 @@
   </PropertyGroup>
   <Import Project="TreeDataGrid.Uno.LinkedAvalonia.props" />
   <ItemGroup>
-        <PackageReference Include="Uno.WinUI" Version="6.5.64" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <Page Include="Themes/**/*.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
+  
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi, I know this PR is still pending, but I was testing it out in Uno and saw I didn't have .net-windows as a target yet. If this is not appropriate, I understand and I can close it. Thanks!

- Target .net10.0 and add uno sdk
- Enable multi-targeting for desktop and WinAppSDK
- Move DataTemplates from App.xaml to MainPage.xaml
- Add conditional preprocessor directives for Uno CollectionChangedEventManager and fallback
- Add WinAppSDK launch profiles
- Remove explicit XAML <Page> includes in TreeDataGrid.Uno which break the build on WASDK target
- Update some vulnerable packages

https://github.com/user-attachments/assets/f3b2d5ee-a221-4e7f-8430-1c8561b01cc7

