### PR TITLE
[11.x] Fix BringIntoView with non-uniform row heights

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -678,9 +678,27 @@ namespace Avalonia.Controls.Primitives
             var viewportStart = Orientation == Orientation.Horizontal ? viewport.X : viewport.Y;
             var viewportEnd = Orientation == Orientation.Horizontal ? viewport.Right : viewport.Bottom;
 
-            // Get or estimate the anchor element from which to start realization.
+            // Get or estimate the anchor element from which to start realization. If we are
+            // scrolling to an element, use that as the anchor so that it is consumed by the
+            // realization pass instead of being left as a disjoint visible child.
             var itemCount = items.Count;
-            var (anchorIndex, anchorU) = GetOrEstimateAnchorElementForViewport(viewportStart, viewportEnd, itemCount);
+            int anchorIndex;
+            double anchorU;
+
+            if (_scrollToIndex >= 0 && _scrollToElement is not null)
+            {
+                anchorIndex = _scrollToIndex;
+                anchorU = Orientation == Orientation.Horizontal ?
+                    _scrollToElement.Bounds.Left :
+                    _scrollToElement.Bounds.Top;
+            }
+            else
+            {
+                (anchorIndex, anchorU) = GetOrEstimateAnchorElementForViewport(
+                    viewportStart,
+                    viewportEnd,
+                    itemCount);
+            }
 
             // Check if the anchor element is not within the currently realized elements.
             var disjunct = anchorIndex < _realizedElements.FirstIndex ||

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridRowsPresenterTests_VariableHeight.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridRowsPresenterTests_VariableHeight.cs
@@ -90,6 +90,43 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
         }
 
         [AvaloniaFact(Timeout = 30000)]
+        public void BringIntoView_Does_Not_Leave_Unrealized_Row_Visible()
+        {
+            var (target, _, items) = CreateTarget(itemCount: 227, rootSize: new Size(100, 600));
+            var targetIndexes = new[] { 206, 5, 185, 25, 220, 100, 200, 0 };
+
+            foreach (var targetIndex in targetIndexes)
+            {
+                var brought = Assert.IsType<TreeDataGridRow>(target.BringIntoView(targetIndex));
+                Layout(target);
+
+                Assert.Equal(targetIndex, brought.RowIndex);
+                Assert.Same(items[targetIndex], brought.DataContext);
+
+                var visibleRows = target.GetVisualChildren()
+                    .Cast<TreeDataGridRow>()
+                    .Where(x => x.IsVisible)
+                    .OrderBy(x => x.Bounds.Top)
+                    .ToList();
+                var realizedRows = target.RealizedElements
+                    .Cast<TreeDataGridRow>()
+                    .OrderBy(x => x.Bounds.Top)
+                    .ToList();
+
+                Assert.Contains(brought, realizedRows);
+                Assert.Equal(realizedRows, visibleRows);
+
+                for (var i = 1; i < visibleRows.Count; ++i)
+                {
+                    Assert.Equal(visibleRows[i - 1].RowIndex + 1, visibleRows[i].RowIndex);
+                    Assert.True(
+                        Math.Abs(visibleRows[i - 1].Bounds.Bottom - visibleRows[i].Bounds.Top) < 0.001,
+                        $"Rows {visibleRows[i - 1].RowIndex} and {visibleRows[i].RowIndex} overlap or have a gap.");
+                }
+            }
+        }
+
+        [AvaloniaFact(Timeout = 30000)]
         public void Pixel_Scrolls_In_Both_Directions_Preserve_Variable_Height_Virtualization()
         {
             var (target, scroll, items) = CreateTarget(itemCount: 40, rootSize: new Size(100, 200));


### PR DESCRIPTION
## Summary

Backports #17 to `release/11.x`.

Fixes incorrect row rendering when BringIntoView targets an unrealized row in a TreeDataGrid with non-uniform row heights.

## Root cause

The target row was created and positioned using an estimated offset, but the following virtualization pass independently selected another row as its realization anchor.

With variable-height rows, these estimates can disagree. The requested row was then left as a disjoint visible child, causing it to overlap the realized row range.

## Fix

Use the pending BringIntoView element as the realization anchor. This ensures that the target row is consumed by the normal realization pass and cannot remain as an orphaned visual.

This matches the behavior of Avalonia’s VirtualizingStackPanel.

## Tests

Added a regression test covering repeated jumps between unrealized, variable-height rows. It verifies that:

- The requested row is realized with the correct model.
- Every visible row belongs to the realized range.
- Realized rows remain contiguous and do not overlap.

All 417 TreeDataGrid tests on the `release/11.x` branch pass.