### PR TITLE
Add BringIntoView sample for non-uniform row heights

### DIFF
--- a/samples/TreeDataGridDemo/MainWindow.axaml
+++ b/samples/TreeDataGridDemo/MainWindow.axaml
@@ -57,13 +57,7 @@
       </DockPanel>
     </TabItem>
     <TabItem Header="Countries">
-      <Grid RowDefinitions="30*,70*">
-        <ListBox ItemsSource="{Binding Countries.Source.Items}" SelectionChanged="SelectingItemsControl_OnSelectionChanged" >
-          </ListBox>
-        <DockPanel Grid.Row="1">
-        
-        <CheckBox Grid.Row="0" IsChecked="True" Name="IsVisibleCheckBox"  DockPanel.Dock="Top"></CheckBox>
-
+      <DockPanel>
         <TextBlock Classes="realized-count" DockPanel.Dock="Bottom"/>
         <StackPanel DockPanel.Dock="Right" Spacing="4" Margin="4 0 0 0">
           <CheckBox IsChecked="{Binding Countries.CellSelection}">Cell Selection</CheckBox>
@@ -88,7 +82,6 @@
         </StackPanel>
         <TreeDataGrid Name="countries"
                       Source="{Binding Countries.Source}"
-                      IsVisible="{Binding #IsVisibleCheckBox.IsChecked}"
                       AutoDragDropRows="True">
           <TreeDataGrid.Resources>
             <!-- Template for Region column cells -->
@@ -114,8 +107,38 @@
           </TreeDataGrid.Styles>
         </TreeDataGrid>
       </DockPanel>
+    </TabItem>
+    <TabItem Header="BringIntoView (Non-uniform rows)">
+      <Grid RowDefinitions="30*,70*">
+        <ListBox ItemsSource="{Binding BringIntoViewNonUniformRows.Source.Items}"
+                 SelectionChanged="BringIntoViewNonUniformRows_SelectionChanged"/>
+        <DockPanel Grid.Row="1">
+          <CheckBox Name="bringIntoViewNonUniformRowsVisible"
+                    IsChecked="True"
+                    DockPanel.Dock="Top">
+            Show TreeDataGrid
+          </CheckBox>
+          <TextBlock Classes="realized-count" DockPanel.Dock="Bottom"/>
+          <TreeDataGrid Name="bringIntoViewNonUniformRowsGrid"
+                        Source="{Binding BringIntoViewNonUniformRows.Source}"
+                        IsVisible="{Binding #bringIntoViewNonUniformRowsVisible.IsChecked}">
+            <TreeDataGrid.Resources>
+              <DataTemplate x:Key="RegionCell" DataType="m:Country">
+                <TextBlock Text="{Binding Region}"/>
+              </DataTemplate>
+              <DataTemplate x:Key="RegionEditCell" DataType="m:Country">
+                <ComboBox ItemsSource="{x:Static m:Countries.Regions}"
+                          SelectedItem="{Binding Region}"/>
+              </DataTemplate>
+            </TreeDataGrid.Resources>
+            <TreeDataGrid.Styles>
+              <Style Selector="TreeDataGrid TreeDataGridRow:nth-last-child(2n)">
+                <Setter Property="Background" Value="#20808080"/>
+              </Style>
+            </TreeDataGrid.Styles>
+          </TreeDataGrid>
+        </DockPanel>
       </Grid>
-
     </TabItem>
     <TabItem Header="Files">
       <DockPanel>

--- a/samples/TreeDataGridDemo/MainWindow.axaml
+++ b/samples/TreeDataGridDemo/MainWindow.axaml
@@ -57,7 +57,13 @@
       </DockPanel>
     </TabItem>
     <TabItem Header="Countries">
-      <DockPanel>
+      <Grid RowDefinitions="30*,70*">
+        <ListBox ItemsSource="{Binding Countries.Source.Items}" SelectionChanged="SelectingItemsControl_OnSelectionChanged" >
+          </ListBox>
+        <DockPanel Grid.Row="1">
+        
+        <CheckBox Grid.Row="0" IsChecked="True" Name="IsVisibleCheckBox"  DockPanel.Dock="Top"></CheckBox>
+
         <TextBlock Classes="realized-count" DockPanel.Dock="Bottom"/>
         <StackPanel DockPanel.Dock="Right" Spacing="4" Margin="4 0 0 0">
           <CheckBox IsChecked="{Binding Countries.CellSelection}">Cell Selection</CheckBox>
@@ -82,6 +88,7 @@
         </StackPanel>
         <TreeDataGrid Name="countries"
                       Source="{Binding Countries.Source}"
+                      IsVisible="{Binding #IsVisibleCheckBox.IsChecked}"
                       AutoDragDropRows="True">
           <TreeDataGrid.Resources>
             <!-- Template for Region column cells -->
@@ -107,6 +114,8 @@
           </TreeDataGrid.Styles>
         </TreeDataGrid>
       </DockPanel>
+      </Grid>
+
     </TabItem>
     <TabItem Header="Files">
       <DockPanel>

--- a/samples/TreeDataGridDemo/MainWindow.axaml.cs
+++ b/samples/TreeDataGridDemo/MainWindow.axaml.cs
@@ -151,5 +151,41 @@ namespace TreeDataGridDemo
             var unrealizedRowCount = rows.GetVisualChildren().Count() - realizedRowCount;
             textBlock.Text = $"{realizedRowCount} rows realized ({unrealizedRowCount} unrealized)";
         }
+
+        private void SelectingItemsControl_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            var countries = this.FindControl<TreeDataGrid>("countries");
+            if (countries is null)
+                return;
+            var treeDataGrid = countries;
+            if (e.AddedItems.Count > 0)
+            {
+                var item = e.AddedItems[0];
+                var source = treeDataGrid.Source;
+                if (item is null || source is null)
+                    return;
+     
+                static int FindDisplayedRowIndex(
+                    ITreeDataGridSource source,
+                    object item)
+                {
+                    for (var i = 0; i < source.Rows.Count; i++)
+                    {
+                        if (ReferenceEquals(source.Rows[i].Model, item))
+                            return i;
+                    }
+
+                    return -1;
+                }
+
+                var rowIndex = FindDisplayedRowIndex(source, item);
+
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (rowIndex >= 0)
+                        treeDataGrid.RowsPresenter?.BringIntoView(rowIndex);
+                }, DispatcherPriority.Loaded);
+            }
+        }
     }
 }

--- a/samples/TreeDataGridDemo/MainWindow.axaml.cs
+++ b/samples/TreeDataGridDemo/MainWindow.axaml.cs
@@ -152,19 +152,18 @@ namespace TreeDataGridDemo
             textBlock.Text = $"{realizedRowCount} rows realized ({unrealizedRowCount} unrealized)";
         }
 
-        private void SelectingItemsControl_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+        private void BringIntoViewNonUniformRows_SelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
-            var countries = this.FindControl<TreeDataGrid>("countries");
-            if (countries is null)
+            var treeDataGrid = this.FindControl<TreeDataGrid>("bringIntoViewNonUniformRowsGrid");
+            if (treeDataGrid is null)
                 return;
-            var treeDataGrid = countries;
+
             if (e.AddedItems.Count > 0)
             {
                 var item = e.AddedItems[0];
                 var source = treeDataGrid.Source;
                 if (item is null || source is null)
                     return;
-     
                 static int FindDisplayedRowIndex(
                     ITreeDataGridSource source,
                     object item)

--- a/samples/TreeDataGridDemo/Models/Countries.cs
+++ b/samples/TreeDataGridDemo/Models/Countries.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace TreeDataGridDemo.Models
@@ -239,23 +238,7 @@ namespace TreeDataGridDemo.Models
             yield return new Country("Zimbabwe", "SUB-SAHARAN AFRICA", 12236805, 390580, 31.3, 0, 0, 67.69, 1900, 90.7, 26.8, 28.01, 21.84);
         }
 
-        public static IReadOnlyList<Country> All => _all ??= CreateCountriesWithVariableLineCounts();
+        public static IReadOnlyList<Country> All => _all ??= GetCountries().ToList();
         public static IReadOnlyList<string> Regions => _regions ??= All.Select(x => x.Region).ToList();
-
-        private static IReadOnlyList<Country> CreateCountriesWithVariableLineCounts()
-        {
-            var random = new Random(42);
-            var result = GetCountries().ToList();
-
-            foreach (var country in result)
-            {
-                var lineCount = random.Next(1, 6);
-                country.Name = string.Join(
-                    Environment.NewLine,
-                    Enumerable.Repeat(country.Name, lineCount));
-            }
-
-            return result;
-        }
     }
 }

--- a/samples/TreeDataGridDemo/Models/Countries.cs
+++ b/samples/TreeDataGridDemo/Models/Countries.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace TreeDataGridDemo.Models
@@ -238,7 +239,23 @@ namespace TreeDataGridDemo.Models
             yield return new Country("Zimbabwe", "SUB-SAHARAN AFRICA", 12236805, 390580, 31.3, 0, 0, 67.69, 1900, 90.7, 26.8, 28.01, 21.84);
         }
 
-        public static IReadOnlyList<Country> All => _all ??= GetCountries().ToList();
+        public static IReadOnlyList<Country> All => _all ??= CreateCountriesWithVariableLineCounts();
         public static IReadOnlyList<string> Regions => _regions ??= All.Select(x => x.Region).ToList();
+
+        private static IReadOnlyList<Country> CreateCountriesWithVariableLineCounts()
+        {
+            var random = new Random(42);
+            var result = GetCountries().ToList();
+
+            foreach (var country in result)
+            {
+                var lineCount = random.Next(1, 6);
+                country.Name = string.Join(
+                    Environment.NewLine,
+                    Enumerable.Repeat(country.Name, lineCount));
+            }
+
+            return result;
+        }
     }
 }

--- a/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Selection;
@@ -14,9 +16,11 @@ namespace TreeDataGridDemo.ViewModels
         private bool _cellSelection;
         private string _filterText = string.Empty;
 
-        public CountriesPageViewModel()
+        public CountriesPageViewModel(bool useVariableHeightRows = false)
         {
-            _data = new ObservableCollection<Country>(Countries.All);
+            _data = new ObservableCollection<Country>(useVariableHeightRows ?
+                CreateCountriesWithVariableHeightRows() :
+                Countries.All);
 
             Source = new FlatTreeDataGridSource<Country>(_data)
                 .WithRowHeaderColumn()
@@ -86,6 +90,32 @@ namespace TreeDataGridDemo.ViewModels
             for (var i = selection.Count - 1; i >= 0; --i)
             {
                 _data.RemoveAt(selection[i][0]);
+            }
+        }
+
+        private static IEnumerable<Country> CreateCountriesWithVariableHeightRows()
+        {
+            var random = new Random(42);
+
+            foreach (var country in Countries.All)
+            {
+                var name = country.Name ?? string.Empty;
+                var lineCount = random.Next(1, 6);
+
+                yield return new Country(
+                    string.Join(Environment.NewLine, Enumerable.Repeat(name, lineCount)),
+                    country.Region,
+                    country.Population,
+                    country.Area,
+                    country.PopulationDensity,
+                    country.CoastLine,
+                    country.NetMigration,
+                    country.InfantMortality,
+                    country.GDP,
+                    country.LiteracyPercent,
+                    country.Phones,
+                    country.BirthRate,
+                    country.DeathRate);
             }
         }
 

--- a/samples/TreeDataGridDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@
     internal class MainWindowViewModel
     {
         private CountriesPageViewModel? _countries;
+        private CountriesPageViewModel? _bringIntoViewNonUniformRows;
         private FilesPageViewModel? _files;
         private WikipediaPageViewModel? _wikipedia;
         private DragDropPageViewModel? _dragDrop;
@@ -11,6 +12,11 @@
         public CountriesPageViewModel Countries
         {
             get => _countries ??= new CountriesPageViewModel();
+        }
+
+        public CountriesPageViewModel BringIntoViewNonUniformRows
+        {
+            get => _bringIntoViewNonUniformRows ??= new CountriesPageViewModel(useVariableHeightRows: true);
         }
 
         public PeopleXamlPageViewModel PeopleXaml


### PR DESCRIPTION
## Summary

Adds a dedicated **BringIntoView (Non-uniform rows)** page to the TreeDataGrid demo for exercising the fix from #17.

The sample:

- Displays countries with deterministic, variable-height names spanning one to five lines.
- Uses a ListBox to repeatedly jump to rows through `RowsPresenter.BringIntoView`.
- Keeps the existing Countries sample and its shared data unchanged.
- Reuses `CountriesPageViewModel` through an optional constructor parameter while giving the repro an isolated cloned dataset.

## Scenario

Selecting a country in the ListBox resolves its displayed row index and schedules `BringIntoView` after the controls are loaded. This provides an interactive reproduction for jumping between unrealized rows with non-uniform heights and makes it easy to verify that visible rows remain contiguous.

## Validation

- `dotnet build samples/TreeDataGridDemo/TreeDataGridDemo.csproj`
- `dotnet test samples/TreeDataGridDemo.Tests/TreeDataGridDemo.Tests.csproj` — 3 passed