### PR TITLE
Fix stale templates when TreeDataGrid cells are recycled

### DIFF
--- a/benchmarks/Avalonia.Controls.TreeDataGrid.Benchmarks/TemplateCellRecyclingBenchmarks.cs
+++ b/benchmarks/Avalonia.Controls.TreeDataGrid.Benchmarks/TemplateCellRecyclingBenchmarks.cs
@@ -1,0 +1,104 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace TreeDataGridBenchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 5, iterationCount: 10)]
+[InvocationCount(64)]
+public class TemplateCellRecyclingBenchmarks
+{
+    private const int OperationCount = 1_000;
+
+    private Window? _window;
+    private Decorator? _host;
+    private TreeDataGridTemplateCell? _cell;
+    private TreeDataGridElementFactory? _factory;
+    private TemplateCell? _firstModel;
+    private TemplateCell? _secondModel;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        AppBuilder.Configure<BenchmarkApplication>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = true })
+            .SetupWithoutStarting();
+
+        var firstTemplate = new FuncDataTemplate<object>((_, _) => new TextBlock());
+        var secondTemplate = new FuncDataTemplate<object>((_, _) => new Border());
+
+        _firstModel = new TemplateCell(new object(), _ => firstTemplate, null, null);
+        _secondModel = new TemplateCell(new object(), _ => secondTemplate, null, null);
+        _factory = new TreeDataGridElementFactory();
+        _cell = new TreeDataGridTemplateCell();
+        _host = new Decorator { Child = _cell };
+        _window = new Window { Content = _host };
+
+        _cell.Realize(_factory, null, _firstModel, 0, 0);
+        _window.Show();
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _window?.Close();
+        _window = null;
+        _host = null;
+        _cell = null;
+        _factory = null;
+        _firstModel = null;
+        _secondModel = null;
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = OperationCount)]
+    public IDataTemplate? SameTemplateProvider()
+    {
+        var cell = _cell!;
+        var factory = _factory!;
+        var host = _host!;
+        var model = _firstModel!;
+
+        for (var i = 0; i < OperationCount; ++i)
+        {
+            host.Child = null;
+            cell.Unrealize();
+            cell.Realize(factory, null, model, 0, 0);
+            host.Child = cell;
+        }
+
+        return cell.ContentTemplate;
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationCount)]
+    public IDataTemplate? AlternatingTemplateProviders()
+    {
+        var cell = _cell!;
+        var factory = _factory!;
+        var host = _host!;
+        var firstModel = _firstModel!;
+        var secondModel = _secondModel!;
+
+        for (var i = 0; i < OperationCount; ++i)
+        {
+            var useSecondTemplate = (i & 1) == 0;
+
+            host.Child = null;
+            cell.Unrealize();
+            cell.Realize(factory, null, useSecondTemplate ? secondModel : firstModel,
+                useSecondTemplate ? 3 : 0, 0);
+            host.Child = cell;
+        }
+
+        return cell.ContentTemplate;
+    }
+
+    private sealed class BenchmarkApplication : Application
+    {
+    }
+}

--- a/samples/TreeDataGridDemo/MainWindow.axaml
+++ b/samples/TreeDataGridDemo/MainWindow.axaml
@@ -4,12 +4,16 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:m="using:TreeDataGridDemo.Models"
         xmlns:vm="using:TreeDataGridDemo.ViewModels"
+        xmlns:views="using:TreeDataGridDemo.Views"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="TreeDataGridDemo.MainWindow"
         x:CompileBindings="True"
         x:DataType="vm:MainWindowViewModel"
         Title="TreeDataGridDemo">
   <TabControl Name="tabs">
+    <TabItem Header="Template Column Reuse">
+      <views:TemplateColumnBugPage DataContext="{Binding TemplateColumnBug}"/>
+    </TabItem>
     <TabItem Header="People (v12 XAML)">
       <DockPanel>
         <TextBlock Name="peopleSelectionText"

--- a/samples/TreeDataGridDemo/MainWindow.axaml.cs
+++ b/samples/TreeDataGridDemo/MainWindow.axaml.cs
@@ -142,11 +142,14 @@ namespace TreeDataGridDemo
             {
                 return;
             }
-            var treeDataGrid = (TreeDataGrid?)((Control)tabItem.Content!).GetLogicalDescendants()
-                .First(x => x is TreeDataGrid tl);
-            var textBlock = (TextBlock)((Control)tabItem.Content!).GetLogicalDescendants()
-                .First(x => x is TextBlock tb && tb.Classes.Contains("realized-count"));
-            var rows = treeDataGrid!.RowsPresenter!;
+            var content = (Control)tabItem.Content!;
+            var treeDataGrid = content.GetLogicalDescendants().OfType<TreeDataGrid>().FirstOrDefault();
+            var textBlock = content.GetLogicalDescendants().OfType<TextBlock>()
+                .FirstOrDefault(x => x.Classes.Contains("realized-count"));
+            var rows = treeDataGrid?.RowsPresenter;
+            if (rows is null || textBlock is null)
+                return;
+
             var realizedRowCount = rows.GetRealizedElements().Count();
             var unrealizedRowCount = rows.GetVisualChildren().Count() - realizedRowCount;
             textBlock.Text = $"{realizedRowCount} rows realized ({unrealizedRowCount} unrealized)";

--- a/samples/TreeDataGridDemo/Models/TemplateColumnItem.cs
+++ b/samples/TreeDataGridDemo/Models/TemplateColumnItem.cs
@@ -1,0 +1,13 @@
+namespace TreeDataGridDemo.Models
+{
+    public sealed class TemplateColumnItem
+    {
+        public required string Name { get; init; }
+
+        public required string Type { get; init; }
+
+        public required string Details { get; init; }
+
+        public bool IsFlagged { get; init; }
+    }
+}

--- a/samples/TreeDataGridDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/MainWindowViewModel.cs
@@ -8,6 +8,7 @@
         private WikipediaPageViewModel? _wikipedia;
         private DragDropPageViewModel? _dragDrop;
         private PeopleXamlPageViewModel? _peopleXaml;
+        private TemplateColumnBugPageViewModel? _templateColumnBug;
 
         public CountriesPageViewModel Countries
         {
@@ -22,6 +23,11 @@
         public PeopleXamlPageViewModel PeopleXaml
         {
             get => _peopleXaml ??= new PeopleXamlPageViewModel();
+        }
+
+        public TemplateColumnBugPageViewModel TemplateColumnBug
+        {
+            get => _templateColumnBug ??= new TemplateColumnBugPageViewModel();
         }
 
         public FilesPageViewModel Files

--- a/samples/TreeDataGridDemo/ViewModels/TemplateColumnBugPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/TemplateColumnBugPageViewModel.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Media;
+using TreeDataGridDemo.Models;
+
+namespace TreeDataGridDemo.ViewModels
+{
+    internal sealed class TemplateColumnBugPageViewModel
+    {
+        public TemplateColumnBugPageViewModel()
+        {
+            Items = Enumerable.Range(1, 200)
+                .Select(index => new TemplateColumnItem
+                {
+                    IsFlagged = index % 3 == 0,
+                    Name = $"Item {index:000}",
+                    Type = $"Type {(char)('A' + (index % 4))}",
+                    Details = $"Details for item {index:000}"
+                })
+                .ToList();
+
+            Source = CreateSource(Items);
+        }
+
+        public IReadOnlyList<TemplateColumnItem> Items { get; }
+
+        public FlatTreeDataGridSource<TemplateColumnItem> Source { get; }
+
+        private static FlatTreeDataGridSource<TemplateColumnItem> CreateSource(
+            IEnumerable<TemplateColumnItem> items)
+        {
+            return new FlatTreeDataGridSource<TemplateColumnItem>(items)
+            {
+                Columns =
+                {
+                    new TemplateColumn<TemplateColumnItem>(
+                        header: "Status",
+                        cellTemplateResourceKey: "IsFlaggedTemplate",
+                        cellEditingTemplateResourceKey: null,
+                        width: new GridLength(50, GridUnitType.Pixel),
+                        options: new TemplateColumnOptions<TemplateColumnItem>
+                        {
+                            CompareAscending = SortAscending(x => x.IsFlagged),
+                            CompareDescending = SortDescending(x => x.IsFlagged),
+                            CanUserResizeColumn = false,
+                            CanUserSortColumn = true
+                        }),
+                    new TextColumn<TemplateColumnItem, string>(
+                        header: "Name",
+                        getter: x => x.Name,
+                        width: GridLength.Star,
+                        options: new TextColumnOptions<TemplateColumnItem>
+                        {
+                            CanUserResizeColumn = true,
+                            CanUserSortColumn = true,
+                            MinWidth = new GridLength(70),
+                            TextTrimming = TextTrimming.CharacterEllipsis,
+                            CompareAscending = SortAscending(x => x.Name),
+                            CompareDescending = SortDescending(x => x.Name)
+                        }),
+                    new TextColumn<TemplateColumnItem, string>(
+                        header: "Type",
+                        getter: x => x.Type,
+                        width: GridLength.Star,
+                        options: new TextColumnOptions<TemplateColumnItem>
+                        {
+                            CanUserResizeColumn = true,
+                            CanUserSortColumn = true,
+                            MinWidth = new GridLength(110),
+                            TextTrimming = TextTrimming.CharacterEllipsis,
+                            CompareAscending = SortAscending(x => x.Type),
+                            CompareDescending = SortDescending(x => x.Type)
+                        }),
+                    new TemplateColumn<TemplateColumnItem>(
+                        header: "Details",
+                        cellTemplateResourceKey: "DetailsTemplate",
+                        cellEditingTemplateResourceKey: null,
+                        width: GridLength.Star,
+                        options: new TemplateColumnOptions<TemplateColumnItem>
+                        {
+                            CompareAscending = SortAscending(x => x.Details),
+                            CompareDescending = SortDescending(x => x.Details),
+                            CanUserResizeColumn = true,
+                            CanUserSortColumn = true,
+                            MinWidth = new GridLength(125)
+                        })
+                }
+            };
+        }
+
+        private static Comparison<TemplateColumnItem?> SortAscending<TValue>(
+            Func<TemplateColumnItem, TValue> selector)
+        {
+            return (x, y) => Compare(x, y, selector);
+        }
+
+        private static Comparison<TemplateColumnItem?> SortDescending<TValue>(
+            Func<TemplateColumnItem, TValue> selector)
+        {
+            return (x, y) => Compare(y, x, selector);
+        }
+
+        private static int Compare<TValue>(
+            TemplateColumnItem? x,
+            TemplateColumnItem? y,
+            Func<TemplateColumnItem, TValue> selector)
+        {
+            if (x is null)
+                return y is null ? 0 : -1;
+            if (y is null)
+                return 1;
+
+            return Comparer<TValue>.Default.Compare(selector(x), selector(y));
+        }
+    }
+}

--- a/samples/TreeDataGridDemo/Views/TemplateColumnBugPage.axaml
+++ b/samples/TreeDataGridDemo/Views/TemplateColumnBugPage.axaml
@@ -1,0 +1,54 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:m="using:TreeDataGridDemo.Models"
+             xmlns:vm="using:TreeDataGridDemo.ViewModels"
+             mc:Ignorable="d"
+             d:DesignWidth="800"
+             d:DesignHeight="450"
+             x:Class="TreeDataGridDemo.Views.TemplateColumnBugPage"
+             x:CompileBindings="True"
+             x:DataType="vm:TemplateColumnBugPageViewModel">
+  <UserControl.Resources>
+    <DataTemplate x:Key="IsFlaggedTemplate" x:DataType="m:TemplateColumnItem">
+      <TextBlock Text="✓"
+                 IsVisible="{Binding IsFlagged}"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center"/>
+    </DataTemplate>
+
+    <DataTemplate x:Key="DetailsTemplate" x:DataType="m:TemplateColumnItem">
+      <TextBlock Text="{Binding Details}"
+                 TextTrimming="CharacterEllipsis"
+                 TextAlignment="Left"
+                 HorizontalAlignment="Stretch"
+                 VerticalAlignment="Center"
+                 Margin="12,0">
+        <ToolTip.Tip>
+          <TextBlock Text="{Binding Details}"/>
+        </ToolTip.Tip>
+      </TextBlock>
+    </DataTemplate>
+  </UserControl.Resources>
+
+  <Grid RowDefinitions="Auto,*">
+    <CheckBox Name="IsVisibleCheckBox"
+              IsChecked="True"
+              Margin="0,0,0,8">
+      Show TreeDataGrid
+    </CheckBox>
+
+    <!--
+      Keep the viewport narrower than the columns' combined minimum width. Scrolling
+      horizontally between the two template columns exercises cross-column cell recycling.
+    -->
+    <TreeDataGrid Name="TemplateColumnGrid"
+                  Grid.Row="1"
+                  Width="260"
+                  HorizontalAlignment="Left"
+                  Source="{Binding Source}"
+                  IsVisible="{Binding #IsVisibleCheckBox.IsChecked}"
+                  SelectionMode="Row"/>
+  </Grid>
+</UserControl>

--- a/samples/TreeDataGridDemo/Views/TemplateColumnBugPage.axaml.cs
+++ b/samples/TreeDataGridDemo/Views/TemplateColumnBugPage.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace TreeDataGridDemo.Views
+{
+    public partial class TemplateColumnBugPage : UserControl
+    {
+        public TemplateColumnBugPage()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTemplateCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTemplateCell.cs
@@ -98,7 +98,9 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnAttachedToLogicalTree(e);
 
-            if (ContentTemplate is null && DataContext is TemplateCell cell)
+            // A detached cell can be recycled into a different template column while retaining
+            // its previous ContentTemplate, so always resolve the current model's templates here.
+            if (DataContext is TemplateCell cell)
             {
                 SetCellTemplate(cell.GetCellTemplate(this));
                 EditingTemplate = cell.GetCellEditingTemplate?.Invoke(this);

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTemplateCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTemplateCellTests.cs
@@ -1,0 +1,44 @@
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Avalonia.Controls.TreeDataGridTests.Primitives
+{
+    public class TreeDataGridTemplateCellTests
+    {
+        [AvaloniaFact]
+        public void Recycled_Cell_Uses_New_Columns_Template_When_Realized_While_Detached()
+        {
+            var firstTemplate = new FuncDataTemplate<object>((_, _) => new TextBlock());
+            var secondTemplate = new FuncDataTemplate<object>((_, _) => new Border());
+            var firstModel = new TemplateCell(new object(), _ => firstTemplate, null, null);
+            var secondModel = new TemplateCell(new object(), _ => secondTemplate, null, null);
+            var factory = new TreeDataGridElementFactory();
+            var cell = new TreeDataGridTemplateCell();
+            var panel = new StackPanel();
+            var window = new Window { Content = panel };
+
+            try
+            {
+                cell.Realize(factory, null, firstModel, 0, 0);
+                panel.Children.Add(cell);
+                window.Show();
+
+                Assert.IsType<TextBlock>(cell.ContentTemplate!.Build(firstModel.Value));
+
+                panel.Children.Remove(cell);
+                cell.Unrealize();
+                cell.Realize(factory, null, secondModel, 3, 0);
+                panel.Children.Add(cell);
+
+                Assert.IsType<Border>(cell.ContentTemplate!.Build(secondModel.Value));
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

This PR fixes a `TreeDataGridTemplateCell` recycling issue that could cause one template column to render another template column's cell template. A common symptom was the first template column intermittently displaying the fourth column's template after cells were detached and recycled.

It also adds a focused sample page that makes the recycling path easy to exercise and a headless regression test that reproduces the faulty lifecycle directly.

## What changed

- Added a **Template Column Reuse** page to `TreeDataGridDemo`.
  - Preserves the reported four-column shape: `TemplateColumn`, `TextColumn`, `TextColumn`, `TemplateColumn`.
  - Uses two distinct keyed data templates for the first and fourth columns.
  - Uses 200 generic items so row and cell virtualization remain active.
  - Constrains the horizontal viewport so scrolling between the two template columns exercises cross-column cell recycling.
  - Includes the original visibility toggle as another detach/reattach path.
- Updated `TreeDataGridTemplateCell.OnAttachedToLogicalTree` to always resolve display and editing templates from the current `TemplateCell` model.
- Added a headless test that realizes a template cell with one column template, detaches and recycles it into another column while detached, and verifies that the second template is used after reattachment.
- Added `TemplateCellRecyclingBenchmarks` with same-provider and alternating-provider detach/reattach workloads, fixed invocation counts, and managed allocation diagnostics.
- Made the demo's realized-row counter tolerate sample pages that intentionally omit its status label.

## Root cause

`TreeDataGridTemplateCell.Unrealize` deliberately preserves `ContentTemplate` to avoid rebuilding the same template when a cell is reused. That optimization is valid when the cell returns to the same template column.

The failure occurs when the detached control is recycled into a different template column:

1. The cell is detached while retaining the previous column's non-null `ContentTemplate`.
2. It is realized with a new `TemplateCell` model while still detached.
3. `OnDataContextChanged` updates the content but cannot resolve the template because the cell is not attached to a logical resource tree.
4. On reattachment, `OnAttachedToLogicalTree` previously resolved the current template only when `ContentTemplate` was null.
5. Because the old template was intentionally retained, the new column continued rendering with the previous column's template.

## Fix

On logical-tree attachment, the cell now resolves its display and editing templates from the current `TemplateCell` model regardless of whether a previous template is present.

This retains the existing optimization: `SetCellTemplate` compares the resolved source template by reference and avoids replacing or rebuilding the recycling wrapper when the template has not changed. Only a genuine cross-template reuse updates the wrapper.

## User impact

Template columns now display the template configured for their current column after virtualization, horizontal scrolling, visibility changes, and other detach/reattach cycles. Text columns and same-template recycling behavior are unchanged.

## Performance impact

The fix adds one cached template-provider invocation and a reference comparison whenever a retained template cell reattaches. `TemplateColumn.GetCellTemplate` returns its already cached `IDataTemplate`, and `SetCellTemplate` returns immediately when that instance has not changed.

A paired benchmark of the semantically equivalent same-template path measured:

- Before the fix: 2.568 us/op, 99.9% CI 2.328-2.807 us.
- With the fix: 2.624 us/op, 99.9% CI 2.297-2.951 us.
- Observed delta: +56 ns/op (+2.2%), with broadly overlapping confidence intervals.
- Managed allocation: unchanged at 3.18 KB/op.

The final benchmark run measured 2.844 us/op for same-provider reattachment and 2.801 us/op for alternating providers. Their confidence intervals also overlap, so the additional lookup is not distinguishable from lifecycle noise at the component level. Alternating providers allocate approximately 112 additional bytes/op because a changed source template correctly creates a replacement recycling wrapper.

No additional provider-identity cache was added. The measured overhead does not justify extra retained state or tighter assumptions about custom template-provider semantics. The benchmark remains in the repository so future lifecycle or recycling changes can be compared under the same workload.

<details>
<summary>Raw BenchmarkDotNet data</summary>

### Environment

```text
BenchmarkDotNet: 0.15.8
OS: macOS Tahoe 26.6 (25G72), Darwin 25.6.0
CPU: Apple M3 Pro, 11 physical/logical cores, ARM64
SDK: .NET SDK 10.0.201
Runtime: .NET 10.0.5, ARM64 RyuJIT, Concurrent Workstation GC
Benchmark job declaration: Runtime=.NET 8.0 (rolled forward to installed .NET 10.0.5)
Warmup iterations: 5
Measurement iterations: 10
Unroll factor: 1
```

The following aggregate rows are copied from BenchmarkDotNet's CSV exports:

```csv
Run,Method,InvocationCount,Mean,Error99.9CI,StdDev,Gen0,Gen1,Allocated
BeforeFix,SameTemplateProvider,32,2.568 us,0.2396 us,0.1426 us,0.3750,0.1250,3.18 KB
FixedPaired,SameTemplateProvider,32,2.624 us,0.3271 us,0.1711 us,0.3750,0.1250,3.18 KB
FixedFinal,SameTemplateProvider,64,2.844 us,0.2698 us,0.1606 us,0.3750,0.1250,3.18 KB
FixedFinal,AlternatingTemplateProviders,64,2.801 us,0.3593 us,0.2377 us,0.3906,0.1250,3.29 KB
```

### Paired before/fixed same-provider workload iterations

Each iteration contains 32,000 logical detach/realize/reattach operations. Values below are the unfiltered `Workload/Actual` measurements from BenchmarkDotNet's compressed JSON exports.

| Iteration | Before total ns | Before ns/op | Fixed total ns | Fixed ns/op |
|---:|---:|---:|---:|---:|
| 1 | 85,028,417 | 2,657.138 | 83,799,875 | 2,618.746 |
| 2 | 77,087,917 | 2,408.997 | 88,109,834 | 2,753.432 |
| 3 | 86,893,791 | 2,715.431 | 88,391,458 | 2,762.233 |
| 4 | 120,474,958 | 3,764.842 | 114,879,167 | 3,589.974 |
| 5 | 78,123,583 | 2,441.362 | 86,857,916 | 2,714.310 |
| 6 | 85,620,959 | 2,675.655 | 74,516,167 | 2,328.630 |
| 7 | 84,422,916 | 2,638.216 | 104,044,791 | 3,251.400 |
| 8 | 74,588,417 | 2,330.888 | 89,746,458 | 2,804.577 |
| 9 | 86,481,542 | 2,702.548 | 82,684,000 | 2,583.875 |
| 10 | 81,284,750 | 2,540.148 | 77,618,458 | 2,425.577 |

BenchmarkDotNet removed one upper outlier from the before-fix statistics and two upper outliers from the fixed statistics. The raw rows above intentionally retain them.

### Final fixed-workload iterations

Each iteration contains 64,000 logical detach/realize/reattach operations. Values are the unfiltered `Workload/Actual` measurements.

| Iteration | Same total ns | Same ns/op | Alternating total ns | Alternating ns/op |
|---:|---:|---:|---:|---:|
| 1 | 182,982,875 | 2,859.107 | 207,651,667 | 3,244.557 |
| 2 | 229,426,333 | 3,584.786 | 173,330,167 | 2,708.284 |
| 3 | 178,042,708 | 2,781.917 | 163,467,750 | 2,554.184 |
| 4 | 181,142,792 | 2,830.356 | 174,017,375 | 2,719.021 |
| 5 | 182,738,167 | 2,855.284 | 174,022,000 | 2,719.094 |
| 6 | 192,872,042 | 3,013.626 | 171,929,459 | 2,686.398 |
| 7 | 196,735,458 | 3,073.992 | 159,943,833 | 2,499.122 |
| 8 | 181,542,625 | 2,836.604 | 190,556,791 | 2,977.450 |
| 9 | 182,428,416 | 2,850.444 | 179,219,500 | 2,800.305 |
| 10 | 159,834,542 | 2,497.415 | 198,817,709 | 3,106.527 |

BenchmarkDotNet removed one upper outlier from the final same-provider aggregate. The raw rows above retain all ten iterations.

### Interpretation limits

- Process priority elevation was unavailable (`Permission denied`), which can increase environmental variance.
- The benchmark was run on one macOS ARM64 machine and should not be used as a cross-platform absolute latency claim.
- The paired means differ by 56 ns/op, while their 99.9% confidence intervals overlap substantially; the data does not support claiming a measurable regression or improvement.
- The benchmark measures the component lifecycle path, not end-to-end frame pacing.

</details>

## Validation

The new regression test was run before the fix and failed because the recycled cell still built the first template's `TextBlock` instead of the second template's `Border`. It passes after the lifecycle change.

- `DOTNET_ROLL_FORWARD=Major dotnet test tests/Avalonia.Controls.TreeDataGrid.Tests/Avalonia.Controls.TreeDataGrid.Tests.csproj --no-restore`
  - 438 passed, 0 failed, 0 skipped.
- `dotnet build samples/TreeDataGridDemo/TreeDataGridDemo.csproj --no-restore`
  - Build succeeded with 0 warnings and 0 errors.
- `dotnet test samples/TreeDataGridDemo.Tests/TreeDataGridDemo.Tests.csproj --no-restore`
  - 3 passed, 0 failed, 0 skipped.
- `DOTNET_ROLL_FORWARD=Major dotnet run -c Release --no-build --project benchmarks/Avalonia.Controls.TreeDataGrid.Benchmarks -- --filter '*TemplateCellRecyclingBenchmarks*' --exporters json markdown --artifacts artifacts/performance/template-cell-final --wakeLock System`
  - Same provider: 2.844 us/op, 3.18 KB/op.
  - Alternating providers: 2.801 us/op, 3.29 KB/op.
  - BenchmarkDotNet 0.15.8 on .NET 10.0.5, macOS 26.6, Apple M3 Pro ARM64.
- `git diff --check`
  - Passed.
