### PR TITLE
[11.x] Fix template reuse across recycled cells

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTemplateCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTemplateCell.cs
@@ -98,7 +98,9 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnAttachedToLogicalTree(e);
 
-            if (ContentTemplate is null && DataContext is TemplateCell cell)
+            // A detached cell can be recycled into a different template column while retaining
+            // its previous ContentTemplate, so always resolve the current model's templates here.
+            if (DataContext is TemplateCell cell)
             {
                 SetCellTemplate(cell.GetCellTemplate(this));
                 EditingTemplate = cell.GetCellEditingTemplate?.Invoke(this);

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTemplateCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTemplateCellTests.cs
@@ -1,0 +1,44 @@
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Avalonia.Controls.TreeDataGridTests.Primitives
+{
+    public class TreeDataGridTemplateCellTests
+    {
+        [AvaloniaFact]
+        public void Recycled_Cell_Uses_New_Columns_Template_When_Realized_While_Detached()
+        {
+            var firstTemplate = new FuncDataTemplate<object>((_, _) => new TextBlock());
+            var secondTemplate = new FuncDataTemplate<object>((_, _) => new Border());
+            var firstModel = new TemplateCell(new object(), _ => firstTemplate, null, null);
+            var secondModel = new TemplateCell(new object(), _ => secondTemplate, null, null);
+            var factory = new TreeDataGridElementFactory();
+            var cell = new TreeDataGridTemplateCell();
+            var panel = new StackPanel();
+            var window = new Window { Content = panel };
+
+            try
+            {
+                cell.Realize(factory, null, firstModel, 0, 0);
+                panel.Children.Add(cell);
+                window.Show();
+
+                Assert.IsType<TextBlock>(cell.ContentTemplate!.Build(firstModel.Value));
+
+                panel.Children.Remove(cell);
+                cell.Unrealize();
+                cell.Realize(factory, null, secondModel, 3, 0);
+                panel.Children.Add(cell);
+
+                Assert.IsType<Border>(cell.ContentTemplate!.Build(secondModel.Value));
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Backport the template-cell recycling fix from #20 to the Avalonia 11 release branch.
- Re-resolve the active `TemplateCell` display and editing templates whenever a recycled cell reattaches to the logical tree.
- Add a headless regression test that recycles one cell from a `TextBlock` template column into a `Border` template column while detached.

## Root cause

`TreeDataGridTemplateCell.OnAttachedToLogicalTree` only resolved templates when `ContentTemplate` was null. A detached cell can be realized for a different template column while still retaining the previous column's template, so reattachment could continue displaying the stale template.

The existing `SetCellTemplate` reference check still avoids replacing the recycling wrapper when the resolved source template has not changed.

## Backport scope

This cherry-picks the fix and regression test from commit `449b3938` on master. The sample page and benchmark added around the original investigation are intentionally not included in the release backport.

## Validation

- Focused regression: 1 passed, 0 failed.
- Full `Avalonia.Controls.TreeDataGrid.Tests` suite: 418 passed, 0 failed, 0 skipped.
- `git diff --check`: passed.

Original fix: #20
