### PR TITLE
Add filtered and sorted displayed-row lookup sample

### DIFF
--- a/samples/TreeDataGridDemo.Tests/TreeDataGridSourceExtensionsTests.cs
+++ b/samples/TreeDataGridDemo.Tests/TreeDataGridSourceExtensionsTests.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using Avalonia.Controls;
+using TreeDataGridDemo.Internal.TreeDataGrid;
+using Xunit;
+
+namespace TreeDataGridDemo.Tests;
+
+public class TreeDataGridSourceExtensionsTests
+{
+    [Fact]
+    public void FindDisplayedRowIndex_UsesReferenceIdentityAndHandlesNull()
+    {
+        var displayed = new Item("Same value");
+        var equalButDifferent = new Item("Same value");
+        var source = new FlatTreeDataGridSource<Item>(new[] { displayed });
+
+        Assert.Equal(0, source.FindDisplayedRowIndex(displayed));
+        Assert.Equal(-1, source.FindDisplayedRowIndex(equalButDifferent));
+        Assert.Equal(-1, source.FindDisplayedRowIndex(null));
+    }
+
+    [Fact]
+    public void FindDisplayedRowIndex_TracksFilteringAndSorting()
+    {
+        var gamma = new Item("Gamma");
+        var alpha = new Item("Alpha");
+        var beta = new Item("Beta");
+        var source = new FlatTreeDataGridSource<Item>(new[] { gamma, alpha, beta })
+            .WithTextColumn("Name", x => x.Name);
+
+        Assert.Equal(1, source.FindDisplayedRowIndex(alpha));
+
+        source.Filter(x => !ReferenceEquals(x, gamma));
+
+        Assert.Equal(-1, source.FindDisplayedRowIndex(gamma));
+        Assert.Equal(0, source.FindDisplayedRowIndex(alpha));
+        Assert.Equal(1, source.FindDisplayedRowIndex(beta));
+
+        ((ITreeDataGridSource)source).SortBy(source.Columns[0], ListSortDirection.Descending);
+
+        Assert.Equal(0, source.FindDisplayedRowIndex(beta));
+        Assert.Equal(1, source.FindDisplayedRowIndex(alpha));
+    }
+
+    private sealed record Item(string Name);
+}

--- a/samples/TreeDataGridDemo/Internal/TreeDataGrid/TreeDataGridSourceExtensions.cs
+++ b/samples/TreeDataGridDemo/Internal/TreeDataGrid/TreeDataGridSourceExtensions.cs
@@ -1,0 +1,24 @@
+using Avalonia.Controls;
+
+namespace TreeDataGridDemo.Internal.TreeDataGrid;
+
+internal static class TreeDataGridSourceExtensions
+{
+    public static int FindDisplayedRowIndex(this ITreeDataGridSource source, object? item)
+    {
+        if (item is null)
+        {
+            return -1;
+        }
+
+        for (var index = 0; index < source.Rows.Count; index++)
+        {
+            if (ReferenceEquals(source.Rows[index].Model, item))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/samples/TreeDataGridDemo/MainWindow.axaml
+++ b/samples/TreeDataGridDemo/MainWindow.axaml
@@ -60,7 +60,7 @@
         </TreeDataGrid>
       </DockPanel>
     </TabItem>
-    <TabItem Header="Countries">
+    <TabItem Header="Countries" IsSelected="True">
       <DockPanel>
         <TextBlock Classes="realized-count" DockPanel.Dock="Bottom"/>
         <StackPanel DockPanel.Dock="Right" Spacing="4" Margin="4 0 0 0">

--- a/samples/TreeDataGridDemo/MainWindow.axaml
+++ b/samples/TreeDataGridDemo/MainWindow.axaml
@@ -112,6 +112,9 @@
         </TreeDataGrid>
       </DockPanel>
     </TabItem>
+    <TabItem Header="Find Displayed Row">
+      <views:FindDisplayedRowIndexPage DataContext="{Binding FindDisplayedRowIndex}"/>
+    </TabItem>
     <TabItem Header="BringIntoView (Non-uniform rows)">
       <Grid RowDefinitions="30*,70*">
         <ListBox ItemsSource="{Binding BringIntoViewNonUniformRows.Source.Items}"

--- a/samples/TreeDataGridDemo/MainWindow.axaml.cs
+++ b/samples/TreeDataGridDemo/MainWindow.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using TreeDataGridDemo.Internal.TreeDataGrid;
 using TreeDataGridDemo.Models;
 using TreeDataGridDemo.ViewModels;
 
@@ -167,20 +168,7 @@ namespace TreeDataGridDemo
                 var source = treeDataGrid.Source;
                 if (item is null || source is null)
                     return;
-                static int FindDisplayedRowIndex(
-                    ITreeDataGridSource source,
-                    object item)
-                {
-                    for (var i = 0; i < source.Rows.Count; i++)
-                    {
-                        if (ReferenceEquals(source.Rows[i].Model, item))
-                            return i;
-                    }
-
-                    return -1;
-                }
-
-                var rowIndex = FindDisplayedRowIndex(source, item);
+                var rowIndex = source.FindDisplayedRowIndex(item);
 
                 Dispatcher.UIThread.Post(() =>
                 {

--- a/samples/TreeDataGridDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@
     internal class MainWindowViewModel
     {
         private CountriesPageViewModel? _countries;
+        private CountriesPageViewModel? _findDisplayedRowIndex;
         private CountriesPageViewModel? _bringIntoViewNonUniformRows;
         private FilesPageViewModel? _files;
         private WikipediaPageViewModel? _wikipedia;
@@ -13,6 +14,11 @@
         public CountriesPageViewModel Countries
         {
             get => _countries ??= new CountriesPageViewModel();
+        }
+
+        public CountriesPageViewModel FindDisplayedRowIndex
+        {
+            get => _findDisplayedRowIndex ??= new CountriesPageViewModel();
         }
 
         public CountriesPageViewModel BringIntoViewNonUniformRows

--- a/samples/TreeDataGridDemo/Views/FindDisplayedRowIndexPage.axaml
+++ b/samples/TreeDataGridDemo/Views/FindDisplayedRowIndexPage.axaml
@@ -1,0 +1,91 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:m="using:TreeDataGridDemo.Models"
+             xmlns:vm="using:TreeDataGridDemo.ViewModels"
+             x:Class="TreeDataGridDemo.Views.FindDisplayedRowIndexPage"
+             x:CompileBindings="True"
+             x:DataType="vm:CountriesPageViewModel">
+  <Grid Margin="8"
+        RowDefinitions="Auto,*"
+        ColumnDefinitions="260,*">
+    <StackPanel Grid.ColumnSpan="2"
+                Margin="0 0 0 8"
+                Spacing="6">
+      <TextBlock Text="Select a country from the complete model list. The grid finds and brings its current displayed row into view after filtering or sorting."
+                 TextWrapping="Wrap"/>
+      <Grid ColumnDefinitions="Auto,260,Auto"
+            ColumnSpacing="8">
+        <Label Target="displayedRowFilterTextBox"
+               VerticalAlignment="Center">
+          _Filter
+        </Label>
+        <TextBox Name="displayedRowFilterTextBox"
+                 Grid.Column="1"
+                 PlaceholderText="Filter by country or region"
+                 Text="{CompiledBinding FilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+        <Button Grid.Column="2"
+                Click="ClearSortClick">
+          Clear sort
+        </Button>
+      </Grid>
+      <TextBlock Text="Click a sortable column header to reorder the displayed rows."
+                 Opacity="0.7"/>
+    </StackPanel>
+
+    <Border Grid.Row="1"
+            Margin="0 0 8 0"
+            Padding="4"
+            BorderBrush="{DynamicResource ThemeBorderLowBrush}"
+            BorderThickness="1"
+            CornerRadius="4">
+      <DockPanel>
+        <TextBlock DockPanel.Dock="Top"
+                   Margin="4"
+                   FontWeight="SemiBold"
+                   Text="All country models"/>
+        <ListBox Name="displayedRowCountryList"
+                 ItemsSource="{CompiledBinding Source.Items}"
+                 SelectionChanged="CountrySelectionChanged">
+          <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="m:Country">
+              <StackPanel Margin="4 2">
+                <TextBlock Text="{CompiledBinding Name}"/>
+                <TextBlock FontSize="11"
+                           Opacity="0.65"
+                           Text="{CompiledBinding Region}"/>
+              </StackPanel>
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+      </DockPanel>
+    </Border>
+
+    <DockPanel Grid.Row="1"
+               Grid.Column="1">
+      <TextBlock Name="displayedRowStatus"
+                 DockPanel.Dock="Bottom"
+                 Margin="4 8 4 0"
+                 Text="Select a country to find its displayed row."
+                 TextWrapping="Wrap"/>
+      <TreeDataGrid Name="displayedRowGrid"
+                    Source="{CompiledBinding Source}">
+        <TreeDataGrid.Resources>
+          <DataTemplate x:Key="RegionCell"
+                        x:DataType="m:Country">
+            <TextBlock Text="{CompiledBinding Region}"/>
+          </DataTemplate>
+          <DataTemplate x:Key="RegionEditCell"
+                        x:DataType="m:Country">
+            <ComboBox ItemsSource="{x:Static m:Countries.Regions}"
+                      SelectedItem="{CompiledBinding Region}"/>
+          </DataTemplate>
+        </TreeDataGrid.Resources>
+        <TreeDataGrid.Styles>
+          <Style Selector="TreeDataGrid TreeDataGridRow:nth-last-child(2n)">
+            <Setter Property="Background" Value="#20808080"/>
+          </Style>
+        </TreeDataGrid.Styles>
+      </TreeDataGrid>
+    </DockPanel>
+  </Grid>
+</UserControl>

--- a/samples/TreeDataGridDemo/Views/FindDisplayedRowIndexPage.axaml.cs
+++ b/samples/TreeDataGridDemo/Views/FindDisplayedRowIndexPage.axaml.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Specialized;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using TreeDataGridDemo.Internal.TreeDataGrid;
+using TreeDataGridDemo.Models;
+using TreeDataGridDemo.ViewModels;
+
+namespace TreeDataGridDemo.Views;
+
+public partial class FindDisplayedRowIndexPage : UserControl
+{
+    private FlatTreeDataGridSource<Country>? _source;
+    private bool _isAttachedToVisualTree;
+
+    public FindDisplayedRowIndexPage()
+    {
+        InitializeComponent();
+    }
+
+    public void ClearSortClick(object? sender, RoutedEventArgs e)
+    {
+        (DataContext as CountriesPageViewModel)?.ClearSort();
+    }
+
+    public void CountrySelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        QueueBringSelectedCountryIntoView();
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        _isAttachedToVisualTree = true;
+        AttachToSource();
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        _isAttachedToVisualTree = false;
+        DetachFromSource();
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        DetachFromSource();
+        base.OnDataContextChanged(e);
+
+        if (_isAttachedToVisualTree)
+        {
+            AttachToSource();
+        }
+    }
+
+    private void AttachToSource()
+    {
+        DetachFromSource();
+
+        _source = (DataContext as CountriesPageViewModel)?.Source;
+
+        if (_source is not null)
+        {
+            _source.Rows.CollectionChanged += RowsCollectionChanged;
+            _source.Sorted += SourceSorted;
+        }
+    }
+
+    private void DetachFromSource()
+    {
+        if (_source is not null)
+        {
+            _source.Rows.CollectionChanged -= RowsCollectionChanged;
+            _source.Sorted -= SourceSorted;
+            _source = null;
+        }
+    }
+
+    private void RowsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        QueueBringSelectedCountryIntoView();
+    }
+
+    private void SourceSorted()
+    {
+        QueueBringSelectedCountryIntoView();
+    }
+
+    private void QueueBringSelectedCountryIntoView()
+    {
+        Dispatcher.UIThread.Post(BringSelectedCountryIntoView, DispatcherPriority.Loaded);
+    }
+
+    private void BringSelectedCountryIntoView()
+    {
+        var countryList = this.FindControl<ListBox>("displayedRowCountryList");
+        var grid = this.FindControl<TreeDataGrid>("displayedRowGrid");
+        var status = this.FindControl<TextBlock>("displayedRowStatus");
+        var country = countryList?.SelectedItem as Country;
+
+        if (_source is null || grid is null || status is null)
+        {
+            return;
+        }
+
+        var rowIndex = _source.FindDisplayedRowIndex(country);
+
+        if (country is null)
+        {
+            status.Text = "Select a country to find its displayed row.";
+        }
+        else if (rowIndex < 0)
+        {
+            status.Text = $"{country.Name} is not displayed by the current filter.";
+        }
+        else
+        {
+            status.Text = $"{country.Name} is displayed at zero-based row index {rowIndex}.";
+            grid.RowsPresenter?.BringIntoView(rowIndex);
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
# Summary

This pull request adds a focused TreeDataGrid demo for finding the displayed row index of a model when the grid is filtered or sorted. It also makes the existing Countries tab the default page shown when the demo starts.

## What changed

- Added a sample-local `FindDisplayedRowIndex` extension for `ITreeDataGridSource`.
  - Returns `-1` for a null model or a model that is not currently displayed.
  - Walks `source.Rows`, so the result reflects the grid's current filtered and sorted row order.
  - Uses reference identity to match the exact model instance represented by a row.
- Replaced the inline displayed-row search in the existing non-uniform-row bring-into-view sample with the shared extension.
- Added a new **Find Displayed Row** sample page that reuses `CountriesPageViewModel` and the existing country column/template setup.
  - Presents the complete country model list alongside the TreeDataGrid.
  - Supports live filtering by country name or region.
  - Supports column-header sorting and a clear-sort action.
  - Recalculates the selected model's displayed row after filter resets and sort changes.
  - Reports when the selected country is excluded by the current filter.
  - Brings a matching displayed row into view without stealing keyboard focus from the filter or column header.
- Registered an independent Countries view-model instance for the new page, keeping its filter and sort state isolated from the existing Countries sample.
- Marked the existing **Countries** tab as selected by default when the demo opens.

## Why

Model collection indexes and displayed row indexes are not interchangeable once TreeDataGrid filtering or sorting is active. Consumers that need to scroll to a particular model must locate that model in `ITreeDataGridSource.Rows`, which represents the current visible ordering. The new page makes that behavior explicit and provides a reusable sample implementation.

## Implementation notes

- The helper remains internal to the demo and does not add or change public library API.
- The new page uses compiled bindings for the Countries view model and country item templates.
- Source event handlers are attached and detached with the page's visual-tree and data-context lifecycle.
- Row collection changes cover filtering updates, while the source `Sorted` event covers both sorting and clearing a sort.

## Commit breakdown

1. `Add displayed row index helper`
   - Adds the helper, unit coverage, and reuse in the existing bring-into-view handler.
2. `Add displayed row lookup sample`
   - Adds the new page, filtering/sorting interactions, source lifecycle handling, and navigation entry.
3. `Make Countries the default sample`
   - Selects the Countries tab on application startup.

## Validation

- `dotnet test samples/TreeDataGridDemo.Tests/TreeDataGridDemo.Tests.csproj --no-restore`
  - 5 passed, 0 failed.
- `DOTNET_ROLL_FORWARD=Major dotnet test tests/Avalonia.Controls.TreeDataGrid.Tests/Avalonia.Controls.TreeDataGrid.Tests.csproj --no-restore --no-build`
  - 449 passed, 0 failed.
- `git diff --check origin/master...HEAD`
  - No whitespace errors.

## User impact

Demo users now land on the Countries sample immediately and have a dedicated example showing how to reliably map a model instance to its current displayed TreeDataGrid row under filtering and sorting. Existing library behavior and public APIs are unchanged.
